### PR TITLE
Fix faults in Make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,8 @@ install-libreg:
 	$(NQ) '  CC  ' $@
 	$(Q)$(CC) -c $(CPPFLAGS) $(CFLAGS) -o $@ $<
 
+crda.o db2rd.o optimize.o: nl80211.h
+
 crda: crda.o
 	$(NQ) '  LD  ' $@
 	$(Q)$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(LDLIBS) $(NLLIBS)


### PR DESCRIPTION
Hello 

This pull request improves the build script of this project.
Specifically, it adds missing Make dependencies so that the targets of the project are re-generated correctly whenever there are updates to any of the dependent source files.
For example, the object file `crda.o` was not dependent on `nl80211.h` even though it should have been. The same applies to files `db2rd.o` and `optimize.o`.

In this way, the project is incrementally built and we no longer sacrifice time in clean builds (i.e., builds after a make clean).